### PR TITLE
Hostname validation

### DIFF
--- a/upd_script/rc.local
+++ b/upd_script/rc.local
@@ -9,7 +9,7 @@
 # In order to enable or disable this script just change the execution
 # bits.
 #
-# By default this script does nothing.
+# By default this script checks the hostname for changes
 echo "  _____            _                                ";
 echo " |  __ \          | |                               ";
 echo " | |  | | _____  _| |_ ___ _ __                     ";
@@ -26,6 +26,6 @@ echo "                                                    ";
 echo " "
 
 # First get update the hostname.
-sudo sh /home/pi/di_update/Raspbian_For_Robots/upd_script/rc.sh
+sudo bash /home/pi/di_update/Raspbian_For_Robots/upd_script/rc.sh
 
 exit 0

--- a/upd_script/rc.sh
+++ b/upd_script/rc.sh
@@ -19,9 +19,9 @@ echo " "
 
 # Now run the code in rc.local that updates the hostname.  
 
-THISHOST=$(hostname -f)	# Gets current hostname
+THISHOST=$(hostname -f) # Gets current hostname
 echo $THISHOST
-read -r NEW_HOST < /boot/hostnames	# Gets hostname in file
+read -r NEW_HOST < /boot/hostnames  # Gets hostname in file
 line=$(head -n 1 /boot/hostnames)
 NEW_HOST=$line
 
@@ -31,30 +31,43 @@ echo $NEW_HOST
 # sleep 5m
 
 
-if [ "$NEW_HOST" != "$THISHOST" ];	# If the hostname isn't the same as the First line of the filename . . .
-	then echo "Host is different name.  Rewriting hosts"
-	# Rewrite hosts
-	IP="127.0.1.1       $NEW_HOST"
-	
-	sudo rm /etc/hosts
-	sudo sh -c "echo '127.0.0.1     localhost' >> /etc/hosts"
-	sudo sh -c "echo '::1           ip6-localhost ip6-loopback' >> /etc/hosts"
-	sudo sh -c "echo 'fe00::0       ip6-localnet' >> /etc/hosts"
-	sudo sh -c "echo 'ff00::0       ip6-mcastprefix' >> /etc/hosts"
-	sudo sh -c "echo 'ff02::1       ip6-allnodes' >> /etc/hosts"
-	sudo sh -c "echo 'ff02::2       ip6-allrouters' >> /etc/hosts"
-	sudo sh -c "echo ' ' >> /etc/hosts"            # Add that blank line in there.
-	sudo sh -c "echo $IP >> /etc/hosts"
+if [ "$NEW_HOST" != "$THISHOST" ];  # If the hostname isn't the same as the First line of the filename . . .
 
-	echo "Delete hostname."
+    then echo "Host is different name."
+    if [[ "$NEW_HOST" =~$REGEX ]]; then
+        echo $NEW_HOST > /home/pi/Desktop/hostname.log
+        rm /home/pi/Desktop/Invalid_hostname.log
+        echo "Rewriting hostname"
 
-	sudo rm /etc/hostname
-	echo "Deleted hostname.  Create new hostname."
-	sudo echo $NEW_HOST >> /etc/hostname
-	echo "New hostname file created."
-	
-	echo "Commit hostname change."
-	sudo /etc/init.d/hostname.sh
-	
-	# sudo reboot
+        # Rewrite hosts
+
+        IP="127.0.1.1       $NEW_HOST"
+        
+        sudo rm /etc/hosts
+        sudo sh -c "echo '127.0.0.1     localhost' >> /etc/hosts"
+        sudo sh -c "echo '::1           ip6-localhost ip6-loopback' >> /etc/hosts"
+        sudo sh -c "echo 'fe00::0       ip6-localnet' >> /etc/hosts"
+        sudo sh -c "echo 'ff00::0       ip6-mcastprefix' >> /etc/hosts"
+        sudo sh -c "echo 'ff02::1       ip6-allnodes' >> /etc/hosts"
+        sudo sh -c "echo 'ff02::2       ip6-allrouters' >> /etc/hosts"
+        sudo sh -c "echo ' ' >> /etc/hosts"            # Add that blank line in there.
+        sudo sh -c "echo $IP >> /etc/hosts"
+
+        echo "Delete hostname."
+
+        sudo rm /etc/hostname
+        echo "Deleted hostname.  Create new hostname."
+        sudo echo $NEW_HOST >> /etc/hostname
+        echo "New hostname file created."
+        
+        echo "Commit hostname change."
+        sudo /etc/init.d/hostname.sh
+    
+        # sudo reboot
+    else 
+
+        echo "INVALID HOSTNAME"
+                echo $NEW_HOST > /home/pi/Desktop/Invalid_hostname.log
+
+    fi
 fi

--- a/upd_script/rc.sh
+++ b/upd_script/rc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # This Script updates the hostname by reading it from "/boot/hostname" 
 echo "  _____            _                                ";
 echo " |  __ \          | |                               ";
@@ -34,7 +34,8 @@ echo $NEW_HOST
 if [ "$NEW_HOST" != "$THISHOST" ];  # If the hostname isn't the same as the First line of the filename . . .
 
     then echo "Host is different name."
-    if [[ "$NEW_HOST" =~$REGEX ]]; then
+    REGEX="^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$";
+    if [[ "$NEW_HOST" =~ $REGEX ]]; then
         echo $NEW_HOST > /home/pi/Desktop/hostname.log
         rm /home/pi/Desktop/Invalid_hostname.log
         echo "Rewriting hostname"


### PR DESCRIPTION
1. switch from dash shell (default sh shell) to bash
2. use of regular expressions to validate the content of /boot/hostnames so the process of switching hostnames is not started if it's an invalid name.