### PR TITLE
Backup script shortcut now run by gksu

### DIFF
--- a/backup/backup.desktop
+++ b/backup/backup.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Comment=Graphical user interface backup
-Exec=lxterminal --title "Backup your files - do not close this window!" --command "sh /home/pi/di_update/Raspbian_For_Robots/backup/run_backup.sh"
+Exec=lxterminal --title "Backup your files - do not close this window!" --command "gksu sh /home/pi/di_update/Raspbian_For_Robots/backup/run_backup.sh"
 Icon=/home/pi/di_update/Raspbian_For_Robots/backup/xarchiver-add.png
 GenericName=Backup Files
 Terminal=false


### PR DESCRIPTION
- The script used to show errors without being run in sudo, so it is now
called with gksu which gives it sudo privileges in Gtk