### PR TITLE
Ensure Scratch examples can be reached via Scratch

### DIFF
--- a/upd_script/upd_scratch_softlinks.sh
+++ b/upd_script/upd_scratch_softlinks.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+#######################################################
+# This scripts adds the soft links that allows
+# users to reach the Dexter Ind Scratch examples from
+# within the Scratch interface
+#######################################################
+
+# BrickPi link
+[ ! -d /usr/share/scratch/Projects/BrickPi ]  && sudo ln -s /home/pi/Desktop/BrickPi/Examples /usr/share/scratch/Projects/BrickPi
+
+# GoPiGo link
+[ ! -d /usr/share/scratch/Projects/GoPiGo ]  && sudo ln -s /home/pi/Desktop/GoPiGo/Software/Scratch/Examples /usr/share/scratch/Projects/GoPiGo
+
+# GrovePi Link
+[ ! -d /usr/share/scratch/Projects/GrovePi ]  && sudo ln -s /home/pi/Desktop/GrovePi/Software/Scratch/Grove_Examples /usr/share/scratch/Projects/GrovePi
+
+

--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -262,6 +262,12 @@ echo "--> ======================================="
 echo " "
 
 ########################################################################
+# ensure the Scratch examples are reachable via Scratch GUI
+# this is done by using soft links
+########################################################################
+bash upd_scratch_softlinks.sh
+
+########################################################################
 ## Install Wifi Adhoc
 ## Sometimes we may not want to do this.  To make it easy, 
 ## Put it inside an if statement


### PR DESCRIPTION
There's an Examples button in Scratch when one does File/Open 
Using softlinks, the DexterEd examples can be reached via this approach. 
This change ensures that the links are always there, on each DI_update