### PR TITLE
Force full path for upd_scratch_softlinks.sh

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -265,7 +265,7 @@ echo " "
 # ensure the Scratch examples are reachable via Scratch GUI
 # this is done by using soft links
 ########################################################################
-bash upd_scratch_softlinks.sh
+bash /home/pi/di_update/Raspbian_For_Robots/upd_script/upd_scratch_softlinks.sh
 
 ########################################################################
 ## Install Wifi Adhoc


### PR DESCRIPTION
Without a full path, the upd_scratch_softlinks.sh is not found when update_all.sh is started through the update GUI