### PR TITLE
Saving a reboot for Cinch

### DIFF
--- a/upd_script/rc.sh
+++ b/upd_script/rc.sh
@@ -18,17 +18,6 @@ echo " "
 THISHOST=$(hostname -f) # Gets current hostname
 echo "Current hostname: $THISHOST"
 
-
-# CINCH: if hostapd exists, ensure that the SSID matches the hostname
-if [[ -f /etc/hostapd/hostapd.conf ]] ; then
-    if ! grep -Rq "$THISHOST" /etc/hostapd/hostapd.conf
-    then
-        sudo sed -i '/^ssid=/s/ssid=.*/ssid='$THISHOST'/g' /etc/hostapd/hostapd.conf
-    fi
-fi
-
-# First get the hostname.
-
 # Now run the code in rc.local that updates the hostname. 
 
 # if we have a file called hostnames in /boot -> rename it to /boot/hostname
@@ -85,7 +74,14 @@ if [ "$NEW_HOST" != "$THISHOST" ];  # If the hostname isn't the same as the Firs
         sudo /etc/init.d/hostname.sh
 
         sudo rm $HOSTNAME_IN
-    
+
+        # CINCH: if hostapd exists, ensure that the SSID matches the hostname
+        if [[ -f /etc/hostapd/hostapd.conf ]] ; then
+            if ! grep -Rq "$THISHOST" /etc/hostapd/hostapd.conf
+            then
+                sudo sed -i '/^ssid=/s/ssid=.*/ssid='$NEW_HOST'/g' /etc/hostapd/hostapd.conf
+            fi
+        fi    
         # sudo reboot
     else 
 

--- a/update_look.sh
+++ b/update_look.sh
@@ -1,0 +1,24 @@
+######################################################################
+# this script changes the logos:
+# 1. the desktop background logo to Dexter
+# 2. the top left icon to a small Dexter
+# 3. background color to white
+######################################################################
+
+# Update background image - Change to dilogo.png
+# These commands don't work: 
+#  sudo rm /etc/alternatives/desktop-background  
+#  sudo cp /home/pi/di_update/Raspbian_For_Robots/dexter_industries_logo.jpg /etc/alternatives/
+
+echo "--> Update the background image on LXE Desktop."
+echo "--> ======================================="
+echo " "
+#sudo rm /usr/share/raspberrypi-artwork/raspberry-pi-logo-small.png
+sudo cp /home/pi/di_update/Raspbian_For_Robots/dexter_industries_logo.png /usr/share/raspberrypi-artwork/dexter_industries_logo.png
+sudo sed -i '/^wallpaper=/s/wallpaper=.*/wallpaper=\/usr\/share\/raspberrypi-artwork\/dexter_industries_logo.png/g' /home/pi/.config/pcmanfm/LXDE-pi/desktop-items-0.conf
+
+
+# update top left icon
+sudo cp /home/pi/di_update/Raspbian_For_Robots/dex.png /usr/share/raspberrypi-artwork/dex.png
+sudo sed -i 's/raspitr/dex/g' /home/pi/.config/lxpanel/LXDE-pi/panels/panel
+


### PR DESCRIPTION
When the user changes the hostname, and it's a Cinch-activated robot, it will now require one less reboot before Cinch matches the hostname. Now down to two reboots, instead of three.

The code is also moved down in the script so as to only be activated once the new hostname has been validated and a hostname change is actually triggered.

NOTE: changing the hostname via raspi-config, or the Raspberry Pi Configuration interface in Jessie does NOT trigger this script. For this script to run, one must drop a text only file in /boot containing the new hostname.