### PR TITLE
Quiet mode 

### DIFF
--- a/upd_script/fetch.sh
+++ b/upd_script/fetch.sh
@@ -1,6 +1,14 @@
 #! /bin/bash
 # This script updates the the code repos on Raspbian for Robots.
 
+# verify quiet mode
+if [ -f /home/pi/quiet_mode ]
+then
+	quiet_mode=1
+else
+	quiet_mode=0
+fi
+
 # GoPiGo Update
 echo "--> Start GoPiGo Update."
 echo "----------"
@@ -18,6 +26,8 @@ echo "------------------"
 sudo chmod +x install.sh
 sudo ./install.sh
 
+
+echo "--> Installing Line Follower Calibration"
 # Install GoPiGo Line Follower Calibration
 sudo rm /home/pi/Desktop/line_follow.desktop
 sudo cp /home/pi/Desktop/GoPiGo/Software/Python/line_follower/line_follow.desktop /home/pi/Desktop/

--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -6,6 +6,18 @@
 ## These Changes to the image are all mandatory.  If you want to run DI
 ## Hardware, you're going to need these changes.
 
+
+# set quiet mode so the user isn't told to reboot before the very end
+touch /home/pi/quiet_mode
+# setting quiet mode
+if [ -f /home/pi/quiet_mode ]
+then
+	quiet_mode=1
+else
+	quiet_mode=0
+fi
+
+
 echo "--> Begin Update."
 echo "--> ======================================="
 sudo dpkg --configure -a
@@ -357,6 +369,7 @@ if [ $VERSION -eq '8' ]; then
   sudo sed -i 's/Wheezy/Jessie/g' /home/pi/di_update/Raspbian_For_Robots/Version
 fi
 
+rm /home/pi/quiet_mode
 
 echo "--> ======================================="
 echo "--> ======================================="

--- a/upd_script/wifi/cinch_setup.sh
+++ b/upd_script/wifi/cinch_setup.sh
@@ -29,7 +29,7 @@ make install
 ifdown wlan0
 
 # Copy modprobe /etc/modprobe.d/cinch-blacklist.conf
-cp $SCRIPTDIR/modprobe.conf etc/modprobe.d/cinch-blacklist.conf
+cp $SCRIPTDIR/modprobe.conf /etc/modprobe.d/cinch-blacklist.conf
 
 # Copy Interfaces /etc/network/interfaces
 if [ -f /etc/network/interfaces ]; then


### PR DESCRIPTION
1. update_all.sh will set a file /home/pi to indicate that quiet mode is required.
2. fetch.sh does set up the quiet_mode variable but does not do anything with it at the moment. I'd rather  have it set properly so future cases can use it
3. cinch_setup.sh was missing a leading / so it would only work if you run it from / directory, 