### PR TITLE
pip install doesn't take a -y

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -46,7 +46,7 @@ sudo apt-get install python-psutil -y 		# Used in Scratch GUI
 sudo apt-get install python-picamera -y
 sudo apt-get install python3-picamera -y
 sudo apt-get install python-smbus python3-smbus -y
-sudo pip install -U RPi.GPIO -y
+sudo pip install -U RPi.GPIO
 
 sudo apt-get install avahi-daemon avahi-utils -y	# Added to help with avahi issues.  2016.01.03
 sudo apt-get install apache2 -y


### PR DESCRIPTION
having -y on pip install generates an error and does not install the library