### PR TITLE
Bad command for Geany

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -49,7 +49,7 @@ sudo pip install -U RPi.GPIO
 echo "geany and piclone"
 # new tools from the foundation
 sudo apt-get install geany piclone -y
-sudo sed -i '/^Exec/ c Exec=sudo geany %F/' /usr/share/raspi-ui-overrides/applications/geany.desktop
+sudo sed -i '/^Exec/ c Exec=sudo geany %F' /usr/share/raspi-ui-overrides/applications/geany.desktop
 
 
 sudo adduser pi i2c


### PR DESCRIPTION
Remove a stray / when setting Geany as sudo
Not tested yet - I just don't want to lose track of it. Need to test it before merging. I'll do that tomorrow.