### PR TITLE
on Wheezy Geany and espeak were not installed

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -48,8 +48,12 @@ sudo pip install -U future # for Python 2/3 compatibility
 
 echo "geany, espeak and piclone"
 # new tools from the foundation
-sudo apt-get install geany espeak  piclone -y
-sudo sed -i '/^Exec/ c Exec=sudo geany %F' /usr/share/raspi-ui-overrides/applications/geany.desktop
+if [ $VERSION -eq '7' ]; then
+    sudo apt-get install geany espeak -y
+else
+	sudo apt-get install geany espeak  piclone -y
+	sudo sed -i '/^Exec/ c Exec=sudo geany %F' /usr/share/raspi-ui-overrides/applications/geany.desktop
+fi
 
 
 sudo adduser pi i2c


### PR DESCRIPTION
 because piclone is not supported on that OS, and they're all installed in one command. Split the command based on OS version
Geany is needed for Mission 12, and GoBoxers are still on Wheezy