### PR TITLE
To redirect any URL to dex.local page

### DIFF
--- a/upd_script/wifi/dnsmasq.conf
+++ b/upd_script/wifi/dnsmasq.conf
@@ -3,6 +3,9 @@ no-resolv
 # Interface to bind to
 interface=wlan0
 # Specify starting_range,end_range,lease_time
+# To redirect all URLs to 10.10.10.10
+listen-address=10.10.10.10
+address=/#/10.10.10.10
 dhcp-range=10.10.10.11,10.10.10.20,12h
 # dns addresses to send to the clients
 server=8.8.8.8

--- a/update_master.sh
+++ b/update_master.sh
@@ -8,6 +8,14 @@
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
+# Check for Cinch and disable redirection of URLs to 10.10.10.10 for internet access
+if [ ! -f /home/pi/cinch ]; then
+    echo "No Cinch Found."
+else
+    sudo sed -i '/listen-address/s/^/#/' /etc/dnsmasq.d/cinch.conf
+    sudo sed -i '/address=\/#/s/^/#/' /etc/dnsmasq.d/cinch.conf
+    sudo /etc/init.d/dnsmasq restart
+fi
 wget -q --tries=2 --timeout=100 --output-document=/dev/null http://raspberrypi.org
 if [ $? -eq 0 ];then
 	echo "Connected.  Do not close this window!"


### PR DESCRIPTION
In Update_master.sh we check if its cinch and disable the redirection of URL so that there is internet access for the update using the Ethernet connected to router.

After disabling, once the update begins it will replace with a new dnsmasq.conf file which will enable the redirection on reboot after the update. Hence after the update all the URLs will be redirected back to dex.local page.