### PR TITLE
Multiple fixes. No more reboot with GrovePi

### DIFF
--- a/auto_detect_robot.py
+++ b/auto_detect_robot.py
@@ -162,7 +162,7 @@ def add_symlink(src):
             os.symlink("/home/pi/Dexter/"+src, "/home/pi/Desktop/"+src)
 
 def remove_symlink(src):
-    if os.path.isdir('/home/pi/Desktop/'+src):
+    if os.path.islink('/home/pi/Desktop/'+src):
         os.unlink('/home/pi/Desktop/'+src)
 
 if __name__ == '__main__':

--- a/upd_script/fetch.sh
+++ b/upd_script/fetch.sh
@@ -1,8 +1,10 @@
 #! /bin/bash
+curl --silent https://raw.githubusercontent.com/DexterInd/script_tools/master/install_script_tools.sh | bash
 
 # Can't use $HOME here as this is being run as sudo and $home defaults to root
 PIHOME=/home/pi
 DEXTER=Dexter
+DESKTOP=Desktop
 DEXTER_PATH=$PIHOME/$DEXTER
 RASPBIAN=$PIHOME/di_update/Raspbian_For_Robots
 
@@ -14,19 +16,20 @@ set_quiet_mode
 set_softlink_for(){
     # if the detected_robot file exists
     # then we will create a softlink onto the desktop
-    # for the detected robots. Non detected robots will not get a softlink
-    # if the file doesn't exist,
+    # for the detected robots. 
+    # Non detected robots will not get a softlink.
+    # If the file doesn't exist,
     # then set all softlinks (assume a simulator mode)
-    delete_folder "$1"
+    # start by deleting the folder/softlink on the desktop
+
+    delete_folder "$PIHOME/$DESKTOP/$1"
     if file_exists $PIHOME/$DEXTER/detected_robot.txt
     then
         if find_in_file "$1" $PIHOME/$DEXTER/detected_robot.txt
         then
-            echo "found in file"
             sudo ln -s -f $DEXTER_PATH/$1 /home/pi/Desktop/$1
         fi   
     else
-        echo "auto_detect file doesn't exist"
         sudo ln -s -f $DEXTER_PATH/$1 /home/pi/Desktop/$1
     fi
 }

--- a/upd_script/fetch.sh
+++ b/upd_script/fetch.sh
@@ -17,23 +17,24 @@ set_softlink_for(){
     # for the detected robots. Non detected robots will not get a softlink
     # if the file doesn't exist,
     # then set all softlinks (assume a simulator mode)
+    delete_folder "$1"
     if file_exists $PIHOME/$DEXTER/detected_robot.txt
     then
         if find_in_file "$1" $PIHOME/$DEXTER/detected_robot.txt
         then
             echo "found in file"
             sudo ln -s -f $DEXTER_PATH/$1 /home/pi/Desktop/$1
-        else
-            delete_folder "$1"
         fi   
     else
-        echo "file doesn't exist"
+        echo "auto_detect file doesn't exist"
         sudo ln -s -f $DEXTER_PATH/$1 /home/pi/Desktop/$1
     fi
 }
 
 set_all_softlinks(){
-    sudo python $PIHOME/$DEXTER/lib/$DEXTER/auto_detect_robot.py
+    # use the file in Raspbian_For_Robots as it hasn't been
+    # transferred yet to ~/Dexter/lib/Dexter
+    sudo python $RASPBIAN/auto_detect_robot.py
     set_softlink_for "GoPiGo"
     set_softlink_for "GrovePi"
     set_softlink_for "BrickPi+"

--- a/upd_script/fetch_arduberry.sh
+++ b/upd_script/fetch_arduberry.sh
@@ -20,6 +20,7 @@ if [ -d "$ARDUBERRY_DIR" ]; then
 else
     cd $DEXTER_PATH
     git clone https://github.com/DexterInd/ArduBerry
+    cd ArduBerry
 fi
 
 #Arduberry does not have a update201612 branch

--- a/upd_script/fetch_grovepi.sh
+++ b/upd_script/fetch_grovepi.sh
@@ -21,17 +21,18 @@ if [ -d "$GROVEPI_DIR" ]; then
     sudo git reset --hard  
     sudo git merge origin/master
 else
-    cd /home/pi/Dexter/
+	echo "Cloning"
+    cd $PIHOME/$DEXTER/
     git clone https://github.com/DexterInd/GrovePi
+    cd GrovePi
 fi
 
 change_branch $BRANCH   # Change to a branch we're working on in the GrovePi Directory. 
                         # Variable $BRANCH comes from /upd_script/fetch.sh
-feedback "Putting link on desktop"
 
 feedback "--> Start GrovePi update install."
 feedback "---------------------------------"
 pushd $PIHOME/$DEXTER/GrovePi/Script > /dev/null
 sudo chmod +x install.sh
-sudo ./install.sh
+sudo bash ./install.sh
 popd > /dev/null


### PR DESCRIPTION
Found the bug that forced GrovePi to reboot. A change directory was missing, so the switch branch wasn't done at the right place and was failing.
fixed the context sensitive folders.
fixed a bug in auto_detect_robot that caused it to crash when attempting to remove a folder that wasn't a softlink
