### PR TITLE
Fixing redirection of URLs to dex.local

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -572,6 +572,9 @@ fi
 if [ ! -f /home/pi/cinch ]; then
     echo "No Cinch Found."
 else
+    feedback "Uncommented lines to redirect URLs to dex.local"
+    sudo sed -i '/listen-address/s/^#//' /etc/dnsmasq.d/cinch.conf
+    sudo sed -i '/address=\/#/s/^#//' /etc/dnsmasq.d/cinch.conf 
     feedback "Found cinch, noting in Version File."
     echo "Cinch Installed."  >> $DEXTER_PATH/Version
 fi

--- a/upd_script/wifi/cinch_setup.sh
+++ b/upd_script/wifi/cinch_setup.sh
@@ -66,6 +66,10 @@ iptables-save > /etc/iptables.ipv4.cinch.nat
 # This creates a file "cinch" in the home directory.
 echo "1" > /home/pi/cinch
 
+# Redirect all URLs to 10.10.10.10
+sudo sed -i '/listen-address/s/^#//' /etc/dnsmasq.d/cinch.conf
+sudo sed -i '/address=\/#/s/^#//' /etc/dnsmasq.d/cinch.conf
+
 # Restart IP Tables
 /etc/init.d/networking restart
 

--- a/upd_script/wifi/dnsmasq.conf
+++ b/upd_script/wifi/dnsmasq.conf
@@ -2,9 +2,9 @@
 no-resolv
 # Interface to bind to
 interface=wlan0
-# To redirect all URLs to 10.10.10.10
-listen-address=10.10.10.10
-address=/#/10.10.10.10
+# Uncomment to redirect all URLs to 10.10.10.10
+#listen-address=10.10.10.10
+#address=/#/10.10.10.10
 # Specify starting_range,end_range,lease_time
 dhcp-range=10.10.10.11,10.10.10.20,12h
 # dns addresses to send to the clients


### PR DESCRIPTION
Now:

Update_master.sh - comments the lines of redirection to provide internet access.
Update_all.sh - Uncomments the lines back to facilitate redirection of URLs.

dnsmasq.conf - Now has the lines of redirection commented which is enabled in Cinch_Setup.sh 
Cinch_Setup.sh - Uncomments the lines to facilitate redirection of URLs at the end of the install
