### PR TITLE
Don't Break IR Receiver

### DIFF
--- a/advanced_communication_options/update_comms_settings.py
+++ b/advanced_communication_options/update_comms_settings.py
@@ -62,7 +62,7 @@ def disable_ir_setting():
 			print "IR already disabled"
 
 def enable_ir_setting():
-	send_command("sudo cp /home/pi/Desktop/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/gobox_ir_receiver_monit.conf /etc/monit/conf.d")
+	send_command("sudo cp /home/pi/Dexter/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/gobox_ir_receiver_monit.conf /etc/monit/conf.d")
 	if 'lirc_dev' in open('/etc/modules').read():
 		if debug: 
 			print "lirc_dev already in /etc/modules"


### PR DESCRIPTION
This file location is what was breaking the IR Receiver.  The remove would work, but the copy wouldn't.

This should change the path and fix issues with the IR Receiver in Scratch and Python.