### PR TITLE
This update should fix the dancing icons issue

### DIFF
--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -136,9 +136,14 @@ install_packages() {
   # You can find firmware commits here:  https://github.com/Hexxeh/rpi-firmware/commits/master to find the specific commit-id of the firmware.
   # As of 2017.06 4.4.50 v7+ is the last working version with the smbus.read_i2c_block_data() command in python.  Before updating the kernel check that
   # the new version works with this function in python.
+  if [ ! $VERSION -eq '7' ]
+  then
   
-  sudo rpi-update 52241088c1da59a359110d39c1875cda56496764  # kernel: Bump to 4.4.50 - v7+
-                                                            # Verify you have the right firmware version with the command - uname -a
+       sudo rpi-update 52241088c1da59a359110d39c1875cda56496764  # kernel: Bump to 4.4.50 - v7+
+                                                                 # Verify you have the right firmware version with the command - uname -a
+  else
+       sudo apt-get install -y raspberrypi-kernel
+  fi
 }
 
 geany_setup(){


### PR DESCRIPTION
When a customer updates wheezy. 

Corrective measure for those that have the dancing icons issue:  `sudo apt-get install -y raspberrypi-kernel`