### PR TITLE
solved issue on not being able to import [DI_Sensors] repo's modules

### DIFF
--- a/upd_script/fetch_sensors.sh
+++ b/upd_script/fetch_sensors.sh
@@ -15,7 +15,7 @@ if folder_exists "$SENSOR_DIR" ; then
     echo "DI_Sensors Directory Exists"
     cd $DEXTER_PATH/DI_Sensors  # Go to directory
     sudo git fetch origin       # Hard reset the git files
-    sudo git reset --hard  
+    sudo git reset --hard
     sudo git merge origin/master
 
 else
@@ -25,8 +25,12 @@ else
     # change_branch $BRANCH  # change to a branch we're working on, if we've defined the branch above.
 fi
 
-sudo python $SENSOR_DIR/Python/setup.py install
-sudo python3 $SENSOR_DIR/Python/setup.py install
+cd $SENSOR_DIR/Python
 
-sudo python $SENSOR_DIR/Python/di_sensors/DHT_Sensor/setup.py install
-sudo python3 $SENSOR_DIR/Python/di_sensors/DHT_Sensor/setup.py install
+sudo python setup.py install
+sudo python3 setup.py install
+
+cd $SENSOR_DIR/Python/di_sensors/DHT_Sensor
+
+sudo python setup.py install
+sudo python3 setup.py install

--- a/upd_script/fetch_sensors.sh
+++ b/upd_script/fetch_sensors.sh
@@ -13,24 +13,25 @@ source /home/pi/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 SENSOR_DIR=$DEXTER_PATH/DI_Sensors
 if folder_exists "$SENSOR_DIR" ; then
     echo "DI_Sensors Directory Exists"
-    cd $DEXTER_PATH/DI_Sensors  # Go to directory
+    pushd $DEXTER_PATH/DI_Sensors  # Go to directory
     sudo git fetch origin       # Hard reset the git files
     sudo git reset --hard
     sudo git merge origin/master
+    popd
 
 else
-    cd $DEXTER_PATH
+    pushd $DEXTER_PATH
     git clone https://github.com/DexterInd/DI_Sensors
-    cd DI_Sensors
-    # change_branch $BRANCH  # change to a branch we're working on, if we've defined the branch above.
+    popd
+
 fi
 
-cd $SENSOR_DIR/Python
-
+pushd $SENSOR_DIR/Python
 sudo python setup.py install
 sudo python3 setup.py install
+popd
 
-cd $SENSOR_DIR/Python/di_sensors/DHT_Sensor
-
+pushd $SENSOR_DIR/Python/di_sensors/DHT_Sensor
 sudo python setup.py install
 sudo python3 setup.py install
+popd


### PR DESCRIPTION
This PR solves the following issue:
* RobertLucian/Raspbian_For_Robots/issues/8

Which was also mentioned a couple of days ago on [DI_Sensors](https://github.com/DexterInd/DI_Sensors) repository:
* https://github.com/DexterInd/DI_Sensors/issues/13

After not being able to import any module from the following 2 packages:
* `DI_Sensors` package
* `Adafruit-DHT` package

I got a solution for it and now the modules are importable.

![proof_that_it_works](https://user-images.githubusercontent.com/26958764/28896180-0bde9c48-77e4-11e7-9184-48cb3e33b4c5.PNG)

* I have tested the process of importing the modules.
* I haven't tested the functionalities though.