### PR TITLE
Wrong path for the ir receiver install script

### DIFF
--- a/advanced_communication_options/advanced_communication_options.py
+++ b/advanced_communication_options/advanced_communication_options.py
@@ -82,9 +82,13 @@ class line_sensor_app(wx.Frame):
             return ("IR Receiver "+ ("Enabled" if update_comms_settings.check_ir_setting() else "Disabled"))
 
     def update_labels(self):
-        self.label_blt.SetLabel(self.current_status("blt"))
-        self.label_uart.SetLabel(self.current_status("UART"))
-        self.label_ir.SetLabel(self.current_status("ir"))
+        # in some cases the bluetooth option is not there
+        try:
+            self.label_uart.SetLabel(self.current_status("UART"))
+            self.label_ir.SetLabel(self.current_status("ir"))
+            self.label_blt.SetLabel(self.current_status("blt"))
+        except:
+            pass
 
     def enable_ir_receiver_button_OnClick(self,event):
         dlg = wx.MessageDialog(self, 'Enabling IR Receiver', ' ', wx.OK|wx.ICON_INFORMATION)

--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -330,10 +330,12 @@ sudo bash $RASPBIAN_PATH//Troubleshooting_GUI/install_troubleshooting_start.sh
 feedback "--> Enable LRC Infrared Control on Pi."
 feedback "--> ======================================="
 feedback " "
-sudo apt-get remove monit --yes # legacy service manager that is no longer required - systemd is the alternative
+# legacy service manager that is no longer required - systemd is the alternative
+sudo apt-get remove monit --yes 
+
+sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/lirc/install.sh
+
 sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/server/install.sh
-sudo chmod +x $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/install.sh
-sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/install.sh
 
 # Update background image - Change to dilogo.png
 # These commands don't work:  sudo rm /etc/alternatives/desktop-background  ;;  sudo cp /home/pi/di_update/Raspbian_For_Robots/dexter_industries_logo.jpg /etc/alternatives/

--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -331,7 +331,7 @@ feedback "--> Enable LRC Infrared Control on Pi."
 feedback "--> ======================================="
 feedback " "
 sudo apt-get remove monit --yes # legacy service manager that is no longer required - systemd is the alternative
-sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/script/ir_install.sh
+sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/server/install.sh
 sudo chmod +x $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/install.sh
 sudo bash $DEXTER_PATH/GoPiGo/Software/Python/ir_remote_control/gobox_ir_receiver_libs/install.sh
 


### PR DESCRIPTION
The GoPiGo IR receiver files have been reorganized at one point and this wasn't kept up to date. 
