### PR TITLE
Ensure PivotPi is cloned in the proper directory when cloning

### DIFF
--- a/upd_script/fetch_pivotpi.sh
+++ b/upd_script/fetch_pivotpi.sh
@@ -7,15 +7,19 @@ curl --silent https://raw.githubusercontent.com/DexterInd/script_tools/master/in
 # needs to be sourced from here when we call this as a standalone
 source /home/pi/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
+pushd $DEXTER_PATH > /dev/null
+
 # if pivotpi folder doesn't exit then clone repo
 if [ ! -d "PivotPi" ]; then
     sudo git clone https://github.com/DexterInd/PivotPi.git
 else
-    cd $DEXTER_PATH/PivotPi  
-    sudo git fetch origin   
-    sudo git reset --hard  
+    cd $DEXTER_PATH/PivotPi
+    sudo git fetch origin
+    sudo git reset --hard
     sudo git merge origin/master
 fi
 #change_branch $BRANCH
 
 sudo bash $DEXTER_PATH/PivotPi/Install/install.sh
+
+popd > /dev/null


### PR DESCRIPTION
This is needed for the new "curl" install procedure