### PR TITLE
Add antenna wifi for GPG3

### DIFF
--- a/antenna_wifi.service
+++ b/antenna_wifi.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Antenna Wifi Indicator
+Requires=novnc.service
+After=novnc.service
+
+
+[Service]
+Type=idle
+User=pi
+WorkingDirectory=/home/pi
+ExecStart=/bin/bash /home/pi/Dexter/antenna_wifi.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/antenna_wifi.sh
+++ b/antenna_wifi.sh
@@ -2,7 +2,7 @@
 # 2 Detect if we have Wifi connection
 # 3 Throw a yellow-orangey LED or turn it off
 
-if grep -q GoPiGo3 $DEXTER_PATH/detected_robot.txt 
+if grep -q GoPiGo3 /home/pi/Dexter/detected_robot.txt 
 then
     if iwgetid --scheme
     then

--- a/antenna_wifi.sh
+++ b/antenna_wifi.sh
@@ -1,0 +1,13 @@
+# 1 Detect if we are on a GoPiGo3
+# 2 Detect if we have Wifi connection
+# 3 Throw a yellow-orangey LED or turn it off
+
+if grep -q GoPiGo3 $DEXTER_PATH/detected_robot.txt 
+then
+    if iwgetid --scheme
+    then
+        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,5,5,0)"
+    else
+        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,0,0,0)"
+    fi
+fi

--- a/upd_script/update_all.sh
+++ b/upd_script/update_all.sh
@@ -263,6 +263,15 @@ install_novnc() {
   feedback " "
 }
 
+install_wifi_antenna() {
+    sudo cp $RASPBIAN_PATH/antenna_wifi.sh $DEXTER_PATH/antenna_wifi.sh
+    sudo cp -r $RASPBIAN_PATH/antenna_wifi.service /etc/systemd/system/
+    sudo chown root:root /etc/systemd/system/antenna_wifi.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable antenna_wifi.service
+    sudo systemctl start antenna_wifi.service
+}
+
 #####################################################################
 # main script
 #####################################################################
@@ -423,6 +432,9 @@ sudo sed -i '41 i\SHELLINABOX_ARGS="--disable-ssl"' /etc/init.d/shellinabox
 
 # Setup noVNC
 install_novnc
+
+# Setup Wifi antenna LED service
+install_wifi_antenna
 
 
 # feedback "Change bash permissions for desktop."


### PR DESCRIPTION
Add a service that checks whether the GPG3 is connected to a wifi service. If so, turn the antenna LED yellow, to indicate it's accessible via Wifi.

This addresses the confusion that some users have when trying Raspbian for Robots and not getting an antenna feedback when booting up the robot.  Of course, the very first boot, there will be no light, as the Wifi info isn't set up yet. But it does give a nice feedback that it's safe to remove the ethernet cable. And on subsequent boots, it helps knowing the status of the robot. 